### PR TITLE
Add TaskSerializer test (#75)

### DIFF
--- a/Sources/Tasks/BasicTasks/CombatTask.cpp
+++ b/Sources/Tasks/BasicTasks/CombatTask.cpp
@@ -60,6 +60,7 @@ MetaData CombatTask::Impl(Player& player1, Player& player2)
 
     // Taunt Verification
     if (target->gameTags[+GameTag::TAUNT] == 0)
+    {
         for (auto& item : player2.field)
         {
             if (item->gameTags[+GameTag::TAUNT] == 1)
@@ -67,6 +68,7 @@ MetaData CombatTask::Impl(Player& player1, Player& player2)
                 return MetaData::COMBAT_FIELD_HAVE_TAUNT;
             }
         }
+    }
 
     // Stealth Verification
     if (target->gameTags[+GameTag::STEALTH] == 1)

--- a/Sources/Tasks/TaskSerializer.cpp
+++ b/Sources/Tasks/TaskSerializer.cpp
@@ -37,6 +37,22 @@ flatbuffers::Offset<FlatData::Card> CreateCard(
         mechanics.emplace_back(static_cast<int>(mechanic));
     }
 
+    std::vector<flatbuffers::Offset<FlatData::PlayRequirements>> requirements;
+    requirements.reserve(card->playRequirements.size());
+    for (const auto& [req, num] : card->playRequirements)
+    {
+        auto playReq = FlatData::CreatePlayRequirements(
+            builder, static_cast<int>(req), num);
+        requirements.emplace_back(playReq);
+    }
+
+    std::vector<flatbuffers::Offset<flatbuffers::String>> entourages;
+    entourages.reserve(card->entourages.size());
+    for (const auto& entourage : card->entourages)
+    {
+        entourages.emplace_back(builder.CreateString(entourage));
+    }
+
     size_t attack = card->attack ? *card->attack : 0;
     size_t health = card->health ? *card->health : 0;
     size_t durability = card->durability ? *card->durability : 0;
@@ -63,7 +79,8 @@ flatbuffers::Offset<FlatData::Card> CreateCard(
         builder.CreateString(card->text), card->isCollectible,
         static_cast<int>(card->cost), static_cast<uint32_t>(attack),
         static_cast<uint32_t>(health), static_cast<uint32_t>(durability),
-        builder.CreateVector(mechanics), 0, 0, card->GetMaxAllowedInDeck());
+        builder.CreateVector(mechanics), builder.CreateVector(requirements),
+        builder.CreateVector(entourages), card->GetMaxAllowedInDeck());
 }
 
 TaskMeta CreateEntityVector(const TaskMetaTrait& trait,

--- a/Tests/UnitTests/Tasks/TaskSerializerTests.cpp
+++ b/Tests/UnitTests/Tasks/TaskSerializerTests.cpp
@@ -191,7 +191,7 @@ TEST(TaskSerializer, CreateResponseMulligan)
 
     auto data = TaskMeta::ConvertTo<FlatData::ResponseMulligan>(resp);
     EXPECT_EQ(resp.id, +TaskID::MULLIGAN);
-    EXPECT_EQ(data->mulligan()->size(), 3);
+    EXPECT_EQ(data->mulligan()->size(), static_cast<size_t>(3));
 
     size_t i = 0;
     for (auto choice : *data->mulligan())

--- a/Tests/UnitTests/Tasks/TaskSerializerTests.cpp
+++ b/Tests/UnitTests/Tasks/TaskSerializerTests.cpp
@@ -126,7 +126,7 @@ TEST(TaskSerializer, CreateEntityVector)
 
     auto vector =
         TaskMeta::ConvertTo<FlatData::EntityVector>(entityVector)->vector();
-    EXPECT_EQ(vector->size(), 2);
+    EXPECT_EQ(vector->size(), static_cast<size_t>(2));
 
     auto deNerubian =
         TestUtils::ConvertCardFrom(nerubian, vector->Get(0)->card());

--- a/Tests/UnitTests/Tasks/TaskSerializerTests.cpp
+++ b/Tests/UnitTests/Tasks/TaskSerializerTests.cpp
@@ -86,9 +86,9 @@ TEST(TaskSerializer, CreateEntity)
     auto buffer = autoEncode(&mNerubian);
     auto minion = flatbuffers::GetRoot<FlatData::Entity>(buffer.get());
     EXPECT_EQ(minion->card()->id()->str(), nerubian->id);
-    EXPECT_EQ(minion->card()->health(), 100);
-    EXPECT_EQ(minion->card()->attack(), 1000);
-    EXPECT_EQ(minion->card()->durability(), 0);
+    EXPECT_EQ(minion->card()->health(), static_cast<size_t>(100));
+    EXPECT_EQ(minion->card()->attack(), static_cast<size_t>(1000));
+    EXPECT_EQ(minion->card()->durability(), static_cast<size_t>(0));
 
     // Rogue Weapon : Poisoned Blade
     const Card* poisonedBlade = cards->FindCardByID("AT_034");
@@ -101,9 +101,9 @@ TEST(TaskSerializer, CreateEntity)
     buffer = autoEncode(&wPoisonedBlade);
     auto weapon = flatbuffers::GetRoot<FlatData::Entity>(buffer.get());
     EXPECT_EQ(weapon->card()->id()->str(), poisonedBlade->id);
-    EXPECT_EQ(weapon->card()->health(), 0);
-    EXPECT_EQ(weapon->card()->attack(), 1);
-    EXPECT_EQ(weapon->card()->durability(), 500);
+    EXPECT_EQ(weapon->card()->health(), static_cast<size_t>(0));
+    EXPECT_EQ(weapon->card()->attack(), static_cast<size_t>(1));
+    EXPECT_EQ(weapon->card()->durability(), static_cast<size_t>(500));
 }
 
 TEST(TaskSerializer, CreateEntityVector)
@@ -206,7 +206,7 @@ TEST(TaskSerializer, CreateResponsePlayCard)
 
     auto data = TaskMeta::ConvertTo<FlatData::ResponsePlayCard>(resp);
     EXPECT_EQ(resp.id, +TaskID::SELECT_CARD);
-    EXPECT_EQ(data->cardIndex(), 10);
+    EXPECT_EQ(data->cardIndex(), static_cast<size_t>(10));
 }
 
 TEST(TaskSerializer, CreateResponsePlayMinion)
@@ -214,7 +214,7 @@ TEST(TaskSerializer, CreateResponsePlayMinion)
     TaskMeta resp = Serializer::CreateResponsePlayMinion(10);
     auto data = TaskMeta::ConvertTo<FlatData::ResponsePlayMinion>(resp);
     EXPECT_EQ(resp.id, +TaskID::SELECT_POSITION);
-    EXPECT_EQ(data->position(), 10);
+    EXPECT_EQ(data->position(), static_cast<size_t>(10));
 }
 
 TEST(TaskSerializer, CreateResponsePlaySpell)
@@ -233,8 +233,8 @@ TEST(TaskSerializer, CreateResponseTarget)
     TaskMeta resp = Serializer::CreateResponseTarget(10, 50);
     auto data = TaskMeta::ConvertTo<FlatData::ResponseTarget>(resp);
     EXPECT_EQ(resp.id, +TaskID::SELECT_TARGET);
-    EXPECT_EQ(data->src(), 10);
-    EXPECT_EQ(data->dst(), 50);
+    EXPECT_EQ(data->src(), static_cast<size_t>(10));
+    EXPECT_EQ(data->dst(), static_cast<size_t>(50));
 }
 
 TEST(TaskSerializer, CreatePlayerSetting)
@@ -294,13 +294,13 @@ TEST(TaskSerializer, CreateGameStatus)
     EXPECT_EQ(status->opponentMana(), player2.existMana);
     EXPECT_EQ(status->currentHero()->card()->id()->str(), "HERO_06");
     EXPECT_EQ(status->opponentHero()->card()->id()->str(), "HERO_04");
-    EXPECT_EQ(status->currentField()->size(), 1);
+    EXPECT_EQ(status->currentField()->size(), static_cast<size_t>(1));
     EXPECT_EQ(status->currentField()->Get(0)->card()->id()->str(), "AT_036t");
-    EXPECT_EQ(status->opponentField()->size(), 1);
+    EXPECT_EQ(status->opponentField()->size(), static_cast<size_t>(1));
     EXPECT_EQ(status->opponentField()->Get(0)->card()->id()->str(), "AT_036t");
-    EXPECT_EQ(status->currentHand()->size(), 1);
+    EXPECT_EQ(status->currentHand()->size(), static_cast<size_t>(1));
     EXPECT_EQ(status->currentHand()->Get(0)->card()->id()->str(), "AT_034");
-    EXPECT_EQ(status->numOpponentHand(), 1);
-    EXPECT_EQ(status->numCurrentDeck(), 0);
-    EXPECT_EQ(status->numOpponentDeck(), 0);
+    EXPECT_EQ(status->numOpponentHand(), static_cast<size_t>(1));
+    EXPECT_EQ(status->numCurrentDeck(), static_cast<size_t>(0));
+    EXPECT_EQ(status->numOpponentDeck(), static_cast<size_t>(0));
 }

--- a/Tests/UnitTests/Utils/TestUtils.cpp
+++ b/Tests/UnitTests/Utils/TestUtils.cpp
@@ -94,6 +94,15 @@ std::unique_ptr<Card> ConvertCardFrom(const Card* card,
     {
         converted->mechanics.emplace_back(GameTag::_from_integral(mechanic));
     }
+    for (auto req : *deserialized->playRequirements())
+    {
+        converted->playRequirements.emplace(
+            PlayReq::_from_integral(req->key_()), req->value());
+    }
+    for (auto entourage : *deserialized->entourages())
+    {
+        converted->entourages.emplace_back(entourage->str());
+    }
     converted->maxAllowedInDeck = deserialized->maxAllowedInDeck();
     converted->Initialize();
 

--- a/Tests/UnitTests/Utils/TestUtils.cpp
+++ b/Tests/UnitTests/Utils/TestUtils.cpp
@@ -49,6 +49,57 @@ TaskMeta GenerateRandomTaskMeta()
     return randomTaskMeta;
 }
 
+std::unique_ptr<Card> ConvertCardFrom(const Card* card,
+                                      const FlatData::Card* deserialized)
+{
+    auto converted = std::make_unique<Card>();
+
+    converted->id = deserialized->id()->str();
+    converted->rarity = Rarity::_from_integral(deserialized->rarity());
+    converted->faction = Faction::_from_integral(deserialized->faction());
+    converted->cardSet = CardSet::_from_integral(deserialized->cardSet());
+    converted->cardClass = CardClass::_from_integral(deserialized->cardClass());
+    converted->cardType = CardType::_from_integral(deserialized->cardType());
+    converted->race = Race::_from_integral(deserialized->race());
+    converted->name = deserialized->name()->str();
+    converted->text = deserialized->text()->str();
+    converted->isCollectible = deserialized->collectible();
+    converted->cost = deserialized->cost();
+#ifndef HEARTHSTONEPP_MACOSX
+    converted->attack = card->attack
+                            ? std::optional<size_t>(deserialized->attack())
+                            : std::nullopt;
+    converted->health = card->health
+                            ? std::optional<size_t>(deserialized->health())
+                            : std::nullopt;
+    converted->durability =
+        card->durability ? std::optional<size_t>(deserialized->durability())
+                         : std::nullopt;
+#else
+    converted->attack =
+        card->attack
+            ? std::experimental::optional<size_t>(deserialized->attack())
+            : std::experimental::nullopt;
+    converted->health =
+        card->health
+            ? std::experimental::optional<size_t>(deserialized->health())
+            : std::experimental::nullopt;
+    converted->durability =
+        card->durability
+            ? std::experimental::optional<size_t>(deserialized->durability())
+            : std::experimental::nullopt;
+#endif
+
+    for (auto mechanic : *deserialized->mechanics())
+    {
+        converted->mechanics.emplace_back(GameTag::_from_integral(mechanic));
+    }
+    converted->maxAllowedInDeck = deserialized->maxAllowedInDeck();
+    converted->Initialize();
+
+    return converted;
+}
+
 void ExpectBufferEqual(const std::unique_ptr<BYTE[]>& buffer1,
                        const std::unique_ptr<BYTE[]>& buffer2, std::size_t size)
 {

--- a/Tests/UnitTests/Utils/TestUtils.h
+++ b/Tests/UnitTests/Utils/TestUtils.h
@@ -17,6 +17,8 @@ TaskMetaTrait GenerateRandomTrait();
 
 TaskMeta GenerateRandomTaskMeta();
 
+std::unique_ptr<Card> ConvertCardFrom(const Card* card, const FlatData::Card* deserialized);
+
 void ExpectBufferEqual(const std::unique_ptr<BYTE[]>& buffer1,
                        const std::unique_ptr<BYTE[]>& buffer2,
                        std::size_t size);


### PR DESCRIPTION
TaskSerializer UnitTest 구현체입니다. 변경 사항은 다음과 같습니다.
- TaskSerializer : CreateCard에서 PlayRequirements와 Entourages를 Serialize합니다.
- TestUtils : ConvertCardFrom 메소드를 구현하였습니다.
- TaskSerializerTests : TaskSerializer에 대한 유닛 테스트를 구현하였습니다.