### PR TITLE
Disable macOS build temporarily (#185)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ matrix:
       script:
         - sh Scripts/travis_build_docker.sh Scripts/Dockerfile.bionic bionic
     # Test OS X 10.12 + Xcode 9 + clang
-    - os: osx
-      osx_image: xcode9
-      compiler: clang
-      script:
-        - sh Scripts/travis_build.sh
+    #- os: osx
+    #  osx_image: xcode9
+    #  compiler: clang
+    #  script:
+    #    - sh Scripts/travis_build.sh
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/utilForever/Hearthstonepp.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/utilForever/Hearthstonepp/context:cpp)
 [![CodeFactor](https://www.codefactor.io/repository/github/utilforever/hearthstonepp/badge)](https://www.codefactor.io/repository/github/utilforever/hearthstonepp)
 
+**Important Notice: We use ```std::any_cast``` in Hearthstone++ core library. ```std::any_cast``` is one of C++17 library features. Unfortunately, it is introduced macOS 10.14. Currently, Travis CI and Azure Pipelines supports macOS 10.13 only. They will support macOS 10.14 soon, so we'll stop supporting it for a while. See [this](https://github.com/utilForever/Hearthstonepp/issues/185) for more details. Thanks. :)**
+
 Hearthstone++ is Hearthstone simulator using C++ with some reinforcement learning. The code is built on C++17 and can be compiled with commonly available compilers such as g++, clang++, or Microsoft Visual Studio. Hearthstone++ currently supports macOS (10.12.6 or later), Ubuntu (17.04 or later), Windows (Visual Studio 2017 or later), and Windows Subsystem for Linux (WSL). Other untested platforms that support C++17 also should be able to build Hearthstone++.
 
 ## Related Repositories

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,8 @@ jobs:
     vmImage: 'Ubuntu-16.04'
   steps:
   - template: Scripts/azure_pipelines_build_linux.yml
-- job: macOS
-  pool:
-    vmImage: 'macOS 10.13'
-  steps:
-  - template: Scripts/azure_pipelines_build_macos.yml
+##- job: macOS
+##  pool:
+##    vmImage: 'macOS 10.13'
+##  steps:
+##  - template: Scripts/azure_pipelines_build_macos.yml


### PR DESCRIPTION
This revision disables macOS build temporarily.

We use std::any_cast in Hearthstone++ core library. std::any_cast is one of C++17 library features. Unfortunately, it is introduced macOS 10.14. Currently, Travis CI and Azure Pipelines supports macOS 10.13 only. They will support macOS 10.14 soon, so we'll stop supporting it for a while. See this for more details. Thanks. :)