### PR TITLE
feat(card-impl): Add power of 'EX1_129' card

### DIFF
--- a/Sources/hspp/CardSets/CoreCardsGen.cpp
+++ b/Sources/hspp/CardSets/CoreCardsGen.cpp
@@ -10,6 +10,7 @@
 #include <hspp/Tasks/SimpleTasks/DamageTask.hpp>
 #include <hspp/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <hspp/Tasks/SimpleTasks/DiscardTask.hpp>
+#include <hspp/Tasks/SimpleTasks/DrawTask.hpp>
 #include <hspp/Tasks/SimpleTasks/HealFullTask.hpp>
 #include <hspp/Tasks/SimpleTasks/HealTask.hpp>
 
@@ -118,7 +119,19 @@ void CoreCardsGen::AddPriestNonCollect(std::map<std::string, Power>& cards)
 
 void CoreCardsGen::AddRogue(std::map<std::string, Power>& cards)
 {
-    (void)cards;
+    Power power;
+
+	// ------------------------------------------ SPELL - ROGUE
+    // [EX1_129] Fan of Knives - COST:3
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: Deal $1 damage to all enemy minions.
+    //       Draw a card.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new DamageTask(EntityType::ENEMIES, 1));
+    power.AddPowerTask(new DrawTask(std::size_t(1)));
+    cards.emplace("EX1_129", power);
 }
 
 void CoreCardsGen::AddRogueNonCollect(std::map<std::string, Power>& cards)

--- a/Sources/hspp/CardSets/CoreCardsGen.cpp
+++ b/Sources/hspp/CardSets/CoreCardsGen.cpp
@@ -121,7 +121,7 @@ void CoreCardsGen::AddRogue(std::map<std::string, Power>& cards)
 {
     Power power;
 
-	// ------------------------------------------ SPELL - ROGUE
+    // ------------------------------------------ SPELL - ROGUE
     // [EX1_129] Fan of Knives - COST:3
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------

--- a/Sources/hspp/CardSets/CoreCardsGen.cpp
+++ b/Sources/hspp/CardSets/CoreCardsGen.cpp
@@ -130,7 +130,7 @@ void CoreCardsGen::AddRogue(std::map<std::string, Power>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new DamageTask(EntityType::ENEMIES, 1));
-    power.AddPowerTask(new DrawTask(std::size_t(1)));
+    power.AddPowerTask(new DrawTask(1u));
     cards.emplace("EX1_129", power);
 }
 

--- a/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
@@ -200,3 +200,52 @@ TEST(CoreCardsGen, CS1_113)
         Task::Run(opPlayer, PlayCardTask(card4, -1, curPlayer.GetHero()));
     EXPECT_EQ(result, TaskStatus::PLAY_CARD_INVALID_TARGET);
 }
+
+TEST(CoreCardsGen, EX1_129)
+{
+    Game game(CardClass::ROGUE, CardClass::PALADIN, PlayerType::PLAYER1);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetCurrentPlayer().GetOpponent();
+    curPlayer.SetMaximumMana(10);
+    curPlayer.SetAvailableMana(10);
+    opPlayer.SetMaximumMana(10);
+    opPlayer.SetAvailableMana(10);
+
+    const auto& curField = curPlayer.GetField();
+    const auto& opField = opPlayer.GetField();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Fan of Knives"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Fan of Knives"));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Acidic Swamp Ooze"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Acidic Swamp Ooze"));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Wolfrider"));
+
+    Entity* entity1 = Entity::GetFromCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wolfrider"));
+    curPlayer.GetDeck().AddCard(*entity1);
+
+    Entity* entity2 = Entity::GetFromCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wolfrider"));
+    curPlayer.GetDeck().AddCard(*entity2);
+
+    Task::Run(opPlayer, PlayCardTask(card3));
+    Task::Run(opPlayer, PlayCardTask(card4));
+    Task::Run(opPlayer, PlayCardTask(card5));
+
+    EXPECT_EQ(curField.GetNumOfMinions(), 0u);
+    EXPECT_EQ(opField.GetNumOfMinions(), 3u);
+
+    Task::Run(curPlayer, PlayCardTask(card1));
+    EXPECT_EQ(opField.GetNumOfMinions(), 2u);
+
+    Task::Run(curPlayer, PlayCardTask(card2));
+    EXPECT_EQ(opField.GetNumOfMinions(), 0u);
+
+    EXPECT_EQ(curPlayer.GetHand().GetNumOfCards(), std::size_t(2));
+}


### PR DESCRIPTION
Implement card 'Fan of Knives' (EX1_129)

Test scenario
1. Op player play minion card
   - one minion with health 1
   - two minions with health 2
2. Cur player deck setting
3. Play 'Fan of Knives' cards twice
   - in each play, check op player's minion number
4. Check cur player's hand number
